### PR TITLE
Add implementations for a node search function.

### DIFF
--- a/fcc_elasticsearch.connect.inc
+++ b/fcc_elasticsearch.connect.inc
@@ -3,9 +3,8 @@
 /**
  * cURL commands for ElasticSearch data retrieval.
  */
-/*
 
-  /**
+/**
  * Request node from ElasticSearch.
  * @param type $nids
  *  An array of node ids.
@@ -28,6 +27,104 @@ function _fcc_es_connect_search_nodes_by_id($nids, $fields = FALSE) {
           '_id' => $nids,
     ))));
 
+    return _fcc_es_connect_post_curl($postfields);
+}
+
+/**
+ * Request the latest nodes from ElasticSearch by type.
+ *
+ * @param type $type
+ * @param type $limit
+ * @param type $offset
+ * @param type $fields
+ * @return type
+ */
+function _fcc_es_connect_get_latest_nodes_by_type($type = 'article', $limit = 15, $offset = 0, $fields = FALSE) {
+    //$fields = array('nid', 'title', 'post_date', 'revision_timestamp', 'published');
+
+    $postfields = json_encode(array(
+      '_source' => ($fields) ? $fields : [],
+      'sort' => array('post_date' => array('order' => 'asc')),
+      'from' => $offset,
+      'size' => $limit,
+      'query' => array(
+        'constant_score' => array(
+          'filter' => array(
+            'bool' => array(
+              'must' => array(
+                'term' => array('_type' => 'article'),
+                'term' => array('domains' => 15),
+              ),
+            ))),
+      ),
+    ));
+
+    return _fcc_es_connect_post_curl($postfields);
+}
+
+/**
+ * Request the latest nodes from ElasticSearch by category id.
+ *
+ * @param type $tid
+ * @param type $limit
+ * @param type $offset
+ * @param type $fields
+ * @return type
+ */
+function _fcc_es_connect_get_latest_nodes_by_tid($tid = 1, $limit = 15, $offset = 0, $fields = FALSE) {
+    //$fields = array('nid', 'title', 'post_date', 'revision_timestamp', 'published');
+
+    $postfields = json_encode(array(
+      '_source' => ($fields) ? $fields : [],
+      'sort' => array('post_date' => array('order' => 'asc')),
+      'from' => $offset,
+      'size' => $limit,
+      'query' => array(
+        'constant_score' => array(
+          'filter' => array(
+            'bool' => array(
+              'must' => array(
+                'term' => array('category.tid' => $tid),
+                'term' => array('domains' => 15),
+              ),
+            ))),
+      ),
+    ));
+
+    return _fcc_es_connect_post_curl($postfields);
+}
+
+/**
+ * Construct queries for Elastic Search.
+ */
+function _fcc_es_connect_make_url() {
+
+    $es_url = variable_get('es_url', '');
+    if (!$es_url) {
+        $es_url = ES_URL;
+    }
+
+    $es_index = variable_get('es_index', '');
+    if (!$es_index) {
+        $es_index = ES_INDEX;
+    }
+
+    $search = array(
+      'url' => $es_url,
+      'index' => $es_index,
+    );
+
+    $query = $search['url'] . '/' . $search['index'] . '/_search';
+
+    return $query;
+}
+
+/**
+ * cURL post command for ElasticSearch.
+ * @param type $postfields
+ * @return type
+ */
+function _fcc_es_connect_post_curl($postfields) {
     $curl = curl_init();
 
     curl_setopt_array($curl, array(
@@ -54,31 +151,6 @@ function _fcc_es_connect_search_nodes_by_id($nids, $fields = FALSE) {
         echo "cURL Error #:" . $err;
     }
     else {
-        return $response;
+        return json_decode($response);
     }
-}
-
-/**
- * Construct queries for Elastic Search.
- */
-function _fcc_es_connect_make_url() {
-
-    $es_url = variable_get('es_url', '');
-    if (!$es_url) {
-        $es_url = ES_URL;
-    }
-
-    $es_index = variable_get('es_index', '');
-    if (!$es_index) {
-        $es_index = ES_INDEX;
-    }
-
-    $search = array(
-      'url' => $es_url,
-      'index' => $es_index,
-    );
-
-    $query = $search['url'] . '/' . $search['index'] . '/_search';
-
-    return $query;
 }

--- a/fcc_elasticsearch.connect.inc
+++ b/fcc_elasticsearch.connect.inc
@@ -12,7 +12,7 @@
  *  An array of fields, or FALSE to load all the fields.
  * @return type
  */
-function _fcc_es_connect_search_nodes_by_id($nids, $fields = FALSE) {
+function _fcc_es_connect_post_nodes_by_id($nids, $fields = FALSE) {
 
     //ELASTICSEARCH: QUERY
     if (empty($nids)) {
@@ -39,12 +39,11 @@ function _fcc_es_connect_search_nodes_by_id($nids, $fields = FALSE) {
  * @param type $fields
  * @return type
  */
-function _fcc_es_connect_get_latest_nodes_by_type($type = 'article', $limit = 15, $offset = 0, $fields = FALSE) {
-    //$fields = array('nid', 'title', 'post_date', 'revision_timestamp', 'published');
+function _fcc_es_connect_post_latest_nodes_by_type($type = 'article', $limit = 15, $offset = 0, $fields = FALSE) {
 
     $postfields = json_encode(array(
       '_source' => ($fields) ? $fields : [],
-      'sort' => array('post_date' => array('order' => 'asc')),
+      'sort' => array('published' => array('order' => 'desc')),
       'from' => $offset,
       'size' => $limit,
       'query' => array(
@@ -71,12 +70,10 @@ function _fcc_es_connect_get_latest_nodes_by_type($type = 'article', $limit = 15
  * @param type $fields
  * @return type
  */
-function _fcc_es_connect_get_latest_nodes_by_tid($tid = 1, $limit = 15, $offset = 0, $fields = FALSE) {
-    //$fields = array('nid', 'title', 'post_date', 'revision_timestamp', 'published');
-
+function _fcc_es_connect_post_latest_nodes_by_tid($tid = 1, $limit = 15, $offset = 0, $fields = FALSE) {
     $postfields = json_encode(array(
       '_source' => ($fields) ? $fields : [],
-      'sort' => array('post_date' => array('order' => 'asc')),
+      'sort' => array('published' => array('order' => 'desc')),
       'from' => $offset,
       'size' => $limit,
       'query' => array(

--- a/fcc_elasticsearch.connect.inc
+++ b/fcc_elasticsearch.connect.inc
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * cURL commands for ElasticSearch data retrieval.
+ */
+/*
+
+  /**
+ * Request node from ElasticSearch.
+ * @param type $nids
+ *  An array of node ids.
+ * @param type $fields
+ *  An array of fields, or FALSE to load all the fields.
+ * @return type
+ */
+function _fcc_es_connect_search_nodes_by_id($nids, $fields = FALSE) {
+
+    //ELASTICSEARCH: QUERY
+    if (empty($nids)) {
+        return;
+    }
+    $query_filter = count($nids) > 1 ? 'terms' : 'term';
+
+    $postfields = json_encode(array(
+      '_source' => ($fields) ? $fields : [],
+      'query' => array(
+        $query_filter => array(
+          '_id' => $nids,
+    ))));
+
+    $curl = curl_init();
+
+    curl_setopt_array($curl, array(
+      CURLOPT_PORT => "9200",
+      CURLOPT_URL => _fcc_es_connect_make_url(),
+      CURLOPT_RETURNTRANSFER => true,
+      CURLOPT_ENCODING => "",
+      CURLOPT_MAXREDIRS => 10,
+      CURLOPT_TIMEOUT => 30,
+      CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+      CURLOPT_CUSTOMREQUEST => "POST",
+      CURLOPT_POSTFIELDS => $postfields,
+      CURLOPT_HTTPHEADER => array(
+        "cache-control: no-cache",
+      ),
+    ));
+
+    $response = curl_exec($curl);
+    $err = curl_error($curl);
+
+    curl_close($curl);
+
+    if ($err) {
+        echo "cURL Error #:" . $err;
+    }
+    else {
+        return $response;
+    }
+}
+
+/**
+ * Construct queries for Elastic Search.
+ */
+function _fcc_es_connect_make_url() {
+
+    $es_url = variable_get('es_url', '');
+    if (!$es_url) {
+        $es_url = ES_URL;
+    }
+
+    $es_index = variable_get('es_index', '');
+    if (!$es_index) {
+        $es_index = ES_INDEX;
+    }
+
+    $search = array(
+      'url' => $es_url,
+      'index' => $es_index,
+    );
+
+    $query = $search['url'] . '/' . $search['index'] . '/_search';
+
+    return $query;
+}

--- a/fcc_elasticsearch.connect.inc
+++ b/fcc_elasticsearch.connect.inc
@@ -52,7 +52,7 @@ function _fcc_es_connect_get_latest_nodes_by_type($type = 'article', $limit = 15
           'filter' => array(
             'bool' => array(
               'must' => array(
-                'term' => array('_type' => 'article'),
+                'term' => array('_type' => $type),
                 'term' => array('domains' => 15),
               ),
             ))),

--- a/fcc_elasticsearch_indexer.module
+++ b/fcc_elasticsearch_indexer.module
@@ -4,6 +4,7 @@
 # Load Includes
 ------------------------------------------------------------------------------*/
 module_load_include( 'inc', 'fcc_elasticsearch_indexer', 'fcc_elasticsearch.common' );
+module_load_include( 'inc', 'fcc_elasticsearch_indexer', 'fcc_elasticsearch.connect' );
 module_load_include( 'inc', 'fcc_elasticsearch_indexer', 'fcc_elasticsearch.types' );
 module_load_include( 'inc', 'fcc_elasticsearch_indexer', 'fcc_elasticsearch_indexer.prepare' );
 module_load_include( 'inc', 'fcc_elasticsearch_indexer', 'fcc_elasticsearch_indexer.fields' );


### PR DESCRIPTION
Add some node search functions for the module.
This will allow us to make use of the node data within the Drupal CMS.

- Single Node
`_fcc_es_connect_post_nodes_by_id('4048657');`

- Single node with body field
`_fcc_es_connect_post_nodes_by_id('4048657', 'body');`

- Single node with multiple fields
`_fcc_es_connect_post_nodes_by_id('4048657', array('body','nid')); `

- Multiple nodes
`_fcc_es_connect_post_nodes_by_id(array('4048658', '4048657'));`